### PR TITLE
Boards status update on task add, remove, board adding, moving

### DIFF
--- a/app/api/boardItems/index.js
+++ b/app/api/boardItems/index.js
@@ -12,7 +12,7 @@ module.exports = function (app) {
                 req.BoardItem = boardItem;
                 next();
             })
-    })
+    });
 
     app.get('/api/projects/:projectId/boardItems/root', function (req, res) {
         let options = {
@@ -58,7 +58,11 @@ module.exports = function (app) {
         };
 
         BoardItemService.create(data)
-            .then((boardItem) => res.json(boardItem))
+            .then((boardItem) => {
+                BoardService
+                    .updateParentsByItem(boardItem.item)
+                    .then(() => res.json(boardItem));
+            })
             .catch((err) => res.status(400).json({error: err}));
     });
 
@@ -67,7 +71,7 @@ module.exports = function (app) {
             .update(req.BoardItem, {timeLog: req.body.timeLog})
             .then((boardItem) => res.json(boardItem))
             .catch((err) => res.status(400).json({error: err}))
-    })
+    });
 
     app.get('/api/boards/:boardId/boardItems', function (req, res) {
         BoardItemService.getItemsByOptions({board: req.Board._id})

--- a/app/api/boardItems/index.js
+++ b/app/api/boardItems/index.js
@@ -81,7 +81,7 @@ module.exports = function (app) {
 
     app.delete('/api/boards/:boardId/boardItems/:boardItemId', function (req, res) {
         BoardItemService
-            .findParentBoardsToUpdateByItem(req.params.boardItemId)
+            .findParentBoardsToUpdateByItem(req.BoardItem._id)
             .then((boardsToUpdate) => {
                 BoardItemService
                     .removeBoardItem(req.params.boardItemId)

--- a/app/config/container.js
+++ b/app/config/container.js
@@ -31,7 +31,7 @@ module.exports = function (container) {
   // services
   container.register('FileService', require('../services/FileService'), ['GridFS']);
   container.register('TaskService', require('../services/TaskService'), ['Task', 'FileService', 'UserService',
-      'SocketService','HistoryService', 'TaskComment', 'BoardItemService']);
+      'SocketService','HistoryService', 'TaskComment', 'BoardItemService', 'BoardService']);
   container.register('UserService', require('../services/UserService'), ['User']);
   container.register('BoardItemService', require('../services/board/BoardItemService'), ['Board', 'BoardItem', 'BoardItemBoard', 'BoardItemTask']);
   container.register('BoardService', require('../services/board/BoardService'), ['Board', 'BoardItemBoard', 'BoardItemService', 'SimpleMetricsService']);

--- a/app/services/board/BoardItemService.js
+++ b/app/services/board/BoardItemService.js
@@ -97,22 +97,20 @@ let BoardItemService = function (Board,
 
             Promise.resolve()
                 .then(() => {
-                    return BoardItem
-                        .find({item: itemId})
-                        .lean()
-                        .exec()
+                    return self.getItemsByOptions({item: itemId})
                         .then((boardItems) => boardItemsToUpdate = boardItems.map((boardItem) => boardItem.board))
                 })
                 .then(() => {
                     if (!boardItemsToUpdate.length) {
                         return boardsToUpdate;
                     } else {
-                        return BoardItem
-                            .find({item: {$in: boardItemsToUpdate}})
-                            .populate('item')
+                        return Board
+                            .find({_id: {$in: boardItemsToUpdate}})
                             .lean()
                             .exec()
-                            .then((boardItems) => boardsToUpdate = boardItems.map((boardItem) => boardItem.item))
+                            .then((boards) => {
+                                boardsToUpdate = boards
+                            }, (err) => reject(err))
                     }
                 })
                 .then(() => resolve(boardsToUpdate));
@@ -150,7 +148,8 @@ let BoardItemService = function (Board,
                             return BoardItem
                                 .remove(query)
                                 .exec()
-                                .then(() => {}, (err) => reject(err))
+                                .then(() => {
+                                }, (err) => reject(err))
                         }, (err) => reject(err));
                 })
                 .then(() => resolve(boardsToUpdate));

--- a/app/services/board/BoardItemService.js
+++ b/app/services/board/BoardItemService.js
@@ -13,7 +13,7 @@ let BoardItemService = function (Board,
                 .exec()
                 .then((item) => resolve(item), (err) => reject(err));
         })
-    }
+    };
 
     this.create = function (data) {
         let self = this;
@@ -56,7 +56,7 @@ let BoardItemService = function (Board,
                     .then((boardItem) => resolve(boardItem), (err) => reject(err))
             },
             (err) => reject(err));
-    }
+    };
 
     this.createBoardItem = function (data) {
         return new Promise(function (resolve, reject) {
@@ -87,32 +87,53 @@ let BoardItemService = function (Board,
 
     this.removeBoardItemsByItem = function (item) {
         let itemId = item && item._id ? item._id : item;
+        let boardItemsToUpdate = [];
+        let boardsToUpdate = [];
 
         return new Promise(function (resolve, reject) {
             if (!itemId) {
-                reject('No itemId during boardItems remove!')
+                return reject('No itemId during boardItems remove!')
             }
 
-            let query = {
-                $or: [
-                    {item: itemId}
-                ]
-            };
-
-            Board
-                .findById(itemId)
-                .then((board) => {
-                    if (board) {
-                        query.$or.push({
-                            board: itemId
-                        })
-                    }
-
-                    BoardItem
-                        .remove(query)
+            Promise.resolve()
+                .then(() => {
+                    return BoardItem
+                        .find({item: itemId})
+                        .lean()
                         .exec()
-                        .then(() => resolve(true), (err) => reject(err))
-                }, (err) => reject(err));
+                        .then((boardItems) => boardItemsToUpdate = boardItems.map((boardItem) => boardItem.board))
+                })
+                .then(() => {
+                    return BoardItem
+                        .find({item: {$in: boardItemsToUpdate}})
+                        .populate('item')
+                        .lean()
+                        .exec()
+                        .then((boardItems) => boardsToUpdate = boardItems.map((boardItem) => boardItem.item))
+                })
+                .then(() => {
+                    let query = {
+                        $or: [
+                            {item: itemId}
+                        ]
+                    };
+
+                    return Board
+                        .findById(itemId)
+                        .then((board) => {
+                            if (board) {
+                                query.$or.push({
+                                    board: itemId
+                                })
+                            }
+
+                            return BoardItem
+                                .remove(query)
+                                .exec()
+                                .then(() => {}, (err) => reject(err))
+                        }, (err) => reject(err));
+                })
+                .then(() => resolve(boardsToUpdate));
         });
     };
     this.removeBoardItem = function (id) {

--- a/app/services/board/BoardService.js
+++ b/app/services/board/BoardService.js
@@ -68,6 +68,10 @@ let BoardService = function (Board,
                 .remove({_id: board.id})
                 .then(() => {
                     BoardItemService.removeBoardItemsByItem(board)
+                        .then((boardsToUpdate) => {
+                            let promises = boardsToUpdate.map((board) => self.updateParentStatus(board));
+                            return Promise.all(promises);
+                        })
                         .then(() => resolve(true))
                         .catch((err) => reject(err));
                 }, (err) => reject(err));

--- a/app/services/board/BoardService.js
+++ b/app/services/board/BoardService.js
@@ -97,17 +97,15 @@ let BoardService = function (Board,
 
     this.updateParentStatus = function (parent) {
         let parentId = parent && parent._id ? parent._id : parent;
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
             BoardItemService
                 .getItemsByOptions({board: parentId})
                 .then((children) => {
                     children = children || [];
 
                     children = children.map((child) => child.item);
-                    return new Promise((res) => {
-                        Board.findById(parentId)
-                            .lean()
-                            .exec()
+                    return new Promise((res, rej) => {
+                        self.getById(parentId)
                             .then((_parent) => {
                                 if (!_parent) {
                                     return resolve();
@@ -115,7 +113,8 @@ let BoardService = function (Board,
 
                                 return self.setParentStatusByChildren(_parent, children);
                             })
-                            .then((updatedParent) => res(updatedParent));
+                            .then((updatedParent) => res(updatedParent))
+                            .catch((err) => rej(err));
                     })
                 })
                 .then((_parent) => {
@@ -123,7 +122,8 @@ let BoardService = function (Board,
                         return self.updateBoard(parent, _parent)
                     }
                 })
-                .then(() => resolve());
+                .then(() => resolve())
+                .catch((err) => reject(err));
         });
     };
 
@@ -142,7 +142,8 @@ let BoardService = function (Board,
                     let promises = parents.map((parentBoard) => self.updateParentStatus(parentBoard));
                     return Promise.all(promises);
                 })
-                .then(() => resolve(item));
+                .then(() => resolve(item))
+                .catch((err) => reject(err));
         });
     };
 


### PR DESCRIPTION
- added updateParentsByItem on boardItems create
- added updateParentsByItem on board creation, board update (move)
- added updateParentsByItem on task update
- added updateParentStatus, updateParentsByItem, setParentStatusByChildren to BoardService
- updated BoardItemsService on removeBoardItemsByItem to collect boards to update after boardItems deletion